### PR TITLE
Raise actual errors when failing to successfully run the migration MAQL

### DIFF
--- a/lib/gutdata/models/project_creator.rb
+++ b/lib/gutdata/models/project_creator.rb
@@ -63,7 +63,7 @@ module GutData
           if !chunks.nil? && !dry_run
             chunks['updateScript']['maqlDdlChunks'].each do |chunk|
               result = project.execute_maql(chunk)
-              fail 'Creating dataset failed' if result['wTaskStatus']['status'] == 'ERROR'
+              raise result['wTaskStatus']['messages'].to_s if result['wTaskStatus']['status'] == 'ERROR'
             end
           end
           chunks


### PR DESCRIPTION
- Previously, this would fail with the unhelpful error message of "Creating dataset failed".
- Now, we should actually be able to figure out what's goin' on.