### PR TITLE
Change most `.info` calls to `.debug` calls

### DIFF
--- a/lib/gutdata/models/datawarehouse.rb
+++ b/lib/gutdata/models/datawarehouse.rb
@@ -17,7 +17,7 @@ module GutData
       # - :auth_token (mandatory)
       # - :summary
       def create(opts)
-        GutData.logger.info "Creating warehouse #{opts[:title]}"
+        GutData.logger.debug "Creating warehouse #{opts[:title]}"
 
         c = client(opts)
         fail ArgumentError, 'No :client specified' if c.nil?

--- a/lib/gutdata/models/project.rb
+++ b/lib/gutdata/models/project.rb
@@ -115,7 +115,7 @@ module GutData
       # - :template (default /projects/blank)
       #
       def create(opts = { :client => GutData.connection }, &block)
-        GutData.logger.info "Creating project #{opts[:title]}"
+        GutData.logger.debug "Creating project #{opts[:title]}"
 
         c = client(opts)
         fail ArgumentError, 'No :client specified' if c.nil?
@@ -928,7 +928,7 @@ module GutData
       dry_run = opts[:dry_run]
 
       if opts[:purge]
-        GutData.logger.info 'Purging old project definitions'
+        GutData.logger.debug 'Purging old project definitions'
         reports.peach(&:purge_report_of_unused_definitions!)
       end
 
@@ -947,31 +947,31 @@ module GutData
           new_item = item.replace(mapping)
           if new_item.json != item.json
             if dry_run
-              GutData.logger.info "Would save #{new_item.uri}. Running in dry run mode"
+              GutData.logger.debug "Would save #{new_item.uri}. Running in dry run mode"
             else
-              GutData.logger.info "Saving #{new_item.uri}"
+              GutData.logger.debug "Saving #{new_item.uri}"
               new_item.save
             end
           end
         end
       end
 
-      GutData.logger.info 'Replacing hidden metrics'
+      GutData.logger.debug 'Replacing hidden metrics'
       local_metrics = rds.pmapcat { |rd| rd.using('metric') }.select { |m| m['deprecated'] == '1' }
       puts "Found #{local_metrics.count} metrics"
       local_metrics.pmap { |m| metrics(m['link']) }.peach do |item|
         new_item = item.replace(mapping)
         if new_item.json != item.json
           if dry_run
-            GutData.logger.info "Would save #{new_item.uri}. Running in dry run mode"
+            GutData.logger.debug "Would save #{new_item.uri}. Running in dry run mode"
           else
-            GutData.logger.info "Saving #{new_item.uri}"
+            GutData.logger.debug "Saving #{new_item.uri}"
             new_item.save
           end
         end
       end
 
-      GutData.logger.info 'Replacing variable values'
+      GutData.logger.debug 'Replacing variable values'
       variables.each do |var|
         var.values.peach do |val|
           val.replace(mapping).save unless dry_run

--- a/lib/gutdata/rest/client.rb
+++ b/lib/gutdata/rest/client.rb
@@ -103,7 +103,7 @@ module GutData
           end
 
           client = Client.new(new_opts)
-          GutData.logger.info("Connected to server with webdav path #{client.user_webdav_path}")
+          GutData.logger.debug("Connected to server with webdav path #{client.user_webdav_path}")
 
           if client
             at_exit do

--- a/lib/gutdata/rest/connection.rb
+++ b/lib/gutdata/rest/connection.rb
@@ -191,7 +191,7 @@ module GutData
           begin
             at_exit { disconnect if @user }
           rescue RestClient::Unauthorized
-            GutData.logger.info 'Already logged out'
+            GutData.logger.debug 'Already logged out'
           ensure
             @at_exit_handler_installed = true
           end
@@ -203,11 +203,11 @@ module GutData
           get('/gdc/account/token', @request_params)
 
           @user = get(get('/gdc/app/account/bootstrap')['bootstrapResource']['accountSetting']['links']['self'])
-          GutData.logger.info("Connected using SST to server #{@server.url} to profile \"#{@user['accountSetting']['login']}\"")
+          GutData.logger.debug("Connected using SST to server #{@server.url} to profile \"#{@user['accountSetting']['login']}\"")
           @auth = {}
           refresh_token :dont_reauth => true
         else
-          GutData.logger.info("Connected using username \"#{username}\" to server #{@server.url}")
+          GutData.logger.debug("Connected using username \"#{username}\" to server #{@server.url}")
           credentials = Connection.construct_login_payload(username, password)
           generate_session_id
           @auth = post(LOGIN_PATH, credentials, :dont_reauth => true)['userLogin']
@@ -215,13 +215,13 @@ module GutData
           refresh_token :dont_reauth => true
           @user = get(@auth['profile'])
         end
-        GutData.logger.info('Connection successful')
+        GutData.logger.debug('Connection successful')
       rescue RestClient::Unauthorized => e
-        GutData.logger.info('Bad Login or Password')
-        GutData.logger.info('Connection failed')
+        GutData.logger.debug('Bad Login or Password')
+        GutData.logger.debug('Connection failed')
         raise e
       rescue RestClient::Forbidden => e
-        GutData.logger.info('Connection failed')
+        GutData.logger.debug('Connection failed')
         raise e
       end
 
@@ -234,7 +234,7 @@ module GutData
           clear_session_id
           delete url if url
         rescue RestClient::Unauthorized
-          GutData.logger.info 'Already disconnected'
+          GutData.logger.debug 'Already disconnected'
         end
 
         @auth = nil
@@ -570,7 +570,7 @@ module GutData
         # if info_message given, log it with request_id (given or generated)
         if options[:info_message]
           request_id = options[:request_id] || generate_request_id
-          GutData.logger.info "#{options[:info_message]} Request id: #{request_id}"
+          GutData.logger.debug "#{options[:info_message]} Request id: #{request_id}"
         end
         options
       end


### PR DESCRIPTION
Pipe logging to debug instead of spamming info with tons of unnecessary info