### PR TITLE
Backport and enhance `AnalyticalDashboard` and `VisualizationObject` classes

### DIFF
--- a/lib/gutdata/models/metadata/analytical_dashboard.rb
+++ b/lib/gutdata/models/metadata/analytical_dashboard.rb
@@ -1,0 +1,51 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+#
+# Copyright (c) 2010-2021 GutData Corporation. All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/analytical_dashboard.rb
+
+require_relative 'analytical_visualization_object'
+
+module GutData
+  class AnalyticalDashboard < GutData::AnalyticalVisualizationObject
+    EMPTY_OBJECT = {
+      'analyticalDashboard' => {
+        'content' => {
+          'filterContext' => '',
+          'layout' => {},
+          'widgets' => []
+        },
+        'meta' => {
+          'deprecated' => '0',
+          'summary' => '',
+          'title' => ''
+        }
+      }
+    }
+
+    ASSIGNABLE_MEMBERS = %i[filterContext layout widgets deprecated summary title]
+
+    class << self
+      # Method intended to get all AnalyticalDashboard objects in a specified project
+      #
+      # @param options [Hash] the options hash
+      # @option options [Boolean] :full with true value will pull in full objects. Default is false value
+      # @return [Array<GutData::AnalyticalDashboard>] Return AnalyticalDashboard list
+      def all(options = { :client => GutData.connection, :project => GutData.project })
+        query('analyticalDashboard', AnalyticalDashboard, options)
+      end
+
+      # Create Analytical Dashboard in the specify project
+      #
+      # @param analytical_dashboard [Hash] the data of object will be created
+      # @param options [Hash] The project that the object will be created in
+      # @return GutData::AnalyticalDashboard object
+      def create(analytical_dashboard = {}, options = { :client => GutData.client, :project => GutData.project })
+        GutData::AnalyticalVisualizationObject.create(analytical_dashboard, AnalyticalDashboard, EMPTY_OBJECT, ASSIGNABLE_MEMBERS, options)
+      end
+    end
+  end
+end

--- a/lib/gutdata/models/metadata/analytical_dashboard.rb
+++ b/lib/gutdata/models/metadata/analytical_dashboard.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 # frozen_string_literal: true
 #
-# Copyright (c) 2010-2021 GutData Corporation. All rights reserved.
+# Copyright (c) 2010-2021 GoodData Corporation. All rights reserved.
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 

--- a/lib/gutdata/models/metadata/analytical_dashboard.rb
+++ b/lib/gutdata/models/metadata/analytical_dashboard.rb
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/analytical_dashboard.rb
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070
 
 require_relative 'analytical_visualization_object'
 

--- a/lib/gutdata/models/metadata/analytical_visualization_object.rb
+++ b/lib/gutdata/models/metadata/analytical_visualization_object.rb
@@ -1,0 +1,32 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+#
+# Copyright (c) 2010-2021 GoodData Corporation. All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/analytical_visualization_object.rb
+
+module GoodData
+  class AnalyticalVisualizationObject < GutData::MdObject
+    class << self
+      # Create a specify object in the specify project
+      #
+      # @param object_data [Hash] the data of object will be created
+      # @param klass [Class] A class used for instantiating the returned data
+      # @param empty_data_object [Hash] the empty data of object will be created
+      # @param assignable_properties [Hash] the properties allow updating
+      # @param options [Hash] The project that the object will be created in
+      # @return klass object
+      def create(object_data, klass, empty_data_object = {}, assignable_properties = [], options = { :client => GutData.client, :project => GutData.project })
+        client, project = GutData.get_client_and_project(GutData::Helpers.symbolize_keys(options))
+
+        res = client.create(klass, GutData::Helpers.deep_dup(GutData::Helpers.stringify_keys(empty_data_object)), :project => project)
+        object_data.each do |k, v|
+          res.send("#{k}=", v) if assignable_properties.include? k
+        end
+        res
+      end
+    end
+  end
+end

--- a/lib/gutdata/models/metadata/analytical_visualization_object.rb
+++ b/lib/gutdata/models/metadata/analytical_visualization_object.rb
@@ -7,8 +7,10 @@
 
 # Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/analytical_visualization_object.rb
 
-module GoodData
+module GutData
   class AnalyticalVisualizationObject < GutData::MdObject
+    include Mixin::Lockable
+
     class << self
       # Create a specify object in the specify project
       #

--- a/lib/gutdata/models/metadata/analytical_visualization_object.rb
+++ b/lib/gutdata/models/metadata/analytical_visualization_object.rb
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/analytical_visualization_object.rb
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070
 
 module GutData
   class AnalyticalVisualizationObject < GutData::MdObject

--- a/lib/gutdata/models/metadata/visualization_object.rb
+++ b/lib/gutdata/models/metadata/visualization_object.rb
@@ -5,7 +5,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/visualization_object.rb
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070
 
 require_relative 'analytical_visualization_object'
 

--- a/lib/gutdata/models/metadata/visualization_object.rb
+++ b/lib/gutdata/models/metadata/visualization_object.rb
@@ -1,0 +1,52 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+#
+# Copyright (c) 2010-2021 GutData Corporation. All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/lib/gooddata/models/metadata/visualization_object.rb
+
+require_relative 'analytical_visualization_object'
+
+module GutData
+  class VisualizationObject < GutData::AnalyticalVisualizationObject
+    EMPTY_OBJECT = {
+      'visualizationObject' => {
+        'content' => {
+          'buckets' => [],
+          'properties' => '',
+          'visualizationClass' => {}
+        },
+        'links' => {},
+        'meta' => {
+          'deprecated' => '0',
+          'summary' => '',
+          'title' => ''
+        }
+      }
+    }
+
+    ASSIGNABLE_MEMBERS = %i[buckets properties visualizationClass deprecated summary title]
+
+    class << self
+      # Method intended to get all VisualizationObject objects in a specified project
+      #
+      # @param options [Hash] the options hash
+      # @option options [Boolean] :full with true value to pull full objects
+      # @return [Array<GutData::VisualizationObject>] Return VisualizationObject list
+      def all(options = { :client => GutData.connection, :project => GutData.project })
+        query('visualizationObject', VisualizationObject, options)
+      end
+
+      # Create Visualization Object in the specify project
+      #
+      # @param visualization_object [Hash] the data of object will be created
+      # @param options [Hash] The project that the object will be created in
+      # @return GutData::VisualizationObject object
+      def create(visualization_object = {}, options = { :client => GutData.client, :project => GutData.project })
+        GutData::AnalyticalVisualizationObject.create(visualization_object, VisualizationObject, EMPTY_OBJECT, ASSIGNABLE_MEMBERS, options)
+      end
+    end
+  end
+end

--- a/lib/gutdata/models/project.rb
+++ b/lib/gutdata/models/project.rb
@@ -406,6 +406,22 @@ module GutData
       GutData::Dashboard[id, project: self, client: client]
     end
 
+    # Helper for getting analytical dashboards of a project
+    #
+    # @param id [String | Number | Object] Anything that you can pass to GutData::AnalyticalDashboard[id]
+    # @return [GutData::AnalyticalDashboard | Array<GutData::AnalyticalDashboard>] analytical dashboard instance or list
+    def analytical_dashboards(id = :all)
+      GutData::AnalyticalDashboard[id, project: self, client: client]
+    end
+
+    # Helper for getting visualization objects of a project
+    #
+    # @param id [String | Number | Object] Anything that you can pass to GutData::VisualizationObject[id]
+    # @return [GutData::VisualizationObject | Array<GutData::VisualizationObject>] visualization object instance or list
+    def visualization_objects(id = :all)
+      GutData::VisualizationObject[id, project: self, client: client]
+    end
+
     def data_permissions(id = :all)
       GutData::MandatoryUserFilter[id, client: client, project: self]
     end

--- a/spec/unit/models/metadata/analytical_dashboard_spec.rb
+++ b/spec/unit/models/metadata/analytical_dashboard_spec.rb
@@ -1,0 +1,70 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+#
+# Copyright (c) 2010-2021 GoodData Corporation. All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/
+
+require 'gutdata'
+
+ANALYTICAL_DASHBOARD_RAW_DATA = {
+  'analyticalDashboard' => {
+    'content' => {
+      'filterContext' => '/gdc/md/w2bbq79qeuqzjhwm9xln0865v7yb/obj/68',
+      'layout' => {},
+      'widgets' => ['/gdc/md/w2bbq79qeuqzjhwm9xln0865v7yb/obj/69']
+    },
+    'meta' => {
+      'author' => '/gdc/account/profile/4e1e8cac228e0ae531b30853248',
+      'uri' => '/gdc/md/w2bbq79qeuqzjhwm9xln0865v7yb/obj/70',
+      'tags' => '',
+      'created' => '2021-04-22 10:23:24',
+      'identifier' => 'aadsy5xXXFZd',
+      'deprecated' => '0',
+      'summary' => 'Test summary',
+      'title' => 'KPI Testing',
+      'category' => 'analyticalDashboard',
+      'updated' => '2021-04-23 13:03:48',
+      'contributor' => '/gdc/account/profile/4e1e8cacc4989228e0ae531b30853248'
+    }
+  }
+}
+
+describe GutData::AnalyticalDashboard do
+  before do
+    @instance = GutData::AnalyticalDashboard.new(GutData::Helpers.deep_dup(ANALYTICAL_DASHBOARD_RAW_DATA))
+  end
+
+  describe '#title' do
+    it 'title' do
+      expect(@instance.title).to eq('KPI Testing')
+    end
+    it 'set title' do
+      @instance.title = 'New title'
+      expect(@instance.title).to eq('New title')
+    end
+  end
+
+  describe '#summary' do
+    it 'summary' do
+      expect(@instance.summary).to eq('Test summary')
+    end
+    it 'set summary' do
+      @instance.summary = 'New summary'
+      expect(@instance.summary).to eq('New summary')
+    end
+  end
+
+  describe '#deprecated' do
+    it 'returns true/false' do
+      expect(@instance.deprecated).to be_falsey
+    end
+    it 'set deprecated flag' do
+      expect(@instance.deprecated).to be_falsey
+      @instance.deprecated = true
+      expect(@instance.deprecated).to be_truthy
+    end
+  end
+end

--- a/spec/unit/models/metadata/visualization_object_spec.rb
+++ b/spec/unit/models/metadata/visualization_object_spec.rb
@@ -1,0 +1,70 @@
+# encoding: UTF-8
+# frozen_string_literal: true
+#
+# Copyright (c) 2010-2021 GoodData Corporation. All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Backported from https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070/
+
+require 'gutdata'
+
+VISUALIZATION_OBJECT_RAW_DATA = {
+    'visualizationObject' => {
+        'content' => {
+            'buckets' => [],
+            'properties' => '',
+            'visualizationClass' => {}
+        },
+        'meta' => {
+            'author' => '/gdc/account/profile/4e1e8cac228e0ae531b30853248',
+            'uri' => '/gdc/md/w2bbq79qeuqzjhwm9xln0865v7yb/obj/70',
+            'tags' => '',
+            'created' => '2021-04-22 10:23:24',
+            'identifier' => 'aabszNAtXFsJ',
+            'deprecated' => '0',
+            'summary' => 'Summary Testing',
+            'title' => 'Dashboard Testing',
+            'category' => 'visualizationObject',
+            'updated' => '2021-04-23 13:03:48',
+            'contributor' => '/gdc/account/profile/4e1e8cacc4989228e0ae531b30853248'
+        }
+    }
+}
+
+describe GutData::VisualizationObject do
+  before do
+    @instance = GutData::VisualizationObject.new(GutData::Helpers.deep_dup(VISUALIZATION_OBJECT_RAW_DATA))
+  end
+
+  describe '#title' do
+    it 'title' do
+      expect(@instance.title).to eq('Dashboard Testing')
+    end
+    it 'set title' do
+      @instance.title = 'New title'
+      expect(@instance.title).to eq('New title')
+    end
+  end
+
+  describe '#summary' do
+    it 'summary' do
+      expect(@instance.summary).to eq('Summary Testing')
+    end
+    it 'set summary' do
+      @instance.summary = 'New summary'
+      expect(@instance.summary).to eq('New summary')
+    end
+  end
+
+  describe '#deprecated' do
+    it 'returns true/false' do
+      expect(@instance.deprecated).to be_falsey
+    end
+    it 'set deprecated flag' do
+      expect(@instance.deprecated).to be_falsey
+      @instance.deprecated = true
+      expect(@instance.deprecated).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Backported from the base `gooddata-ruby` gem here: https://github.com/gooddata/gooddata-ruby/blob/6153ef930e089a3e7c98af63075d193884916070

- Updated the base `AnalyticalVisualizationObject` to mixin `Lockable` 
- Overrides `(un)lock_with_dependecies!` methods to handle analytical dashboard specific dependencies