### PR TITLE
Add new classes to `MdObjectIndexer.[]` method

### DIFF
--- a/lib/gutdata/mixins/md_object_indexer.rb
+++ b/lib/gutdata/mixins/md_object_indexer.rb
@@ -50,6 +50,10 @@ module GutData
             md_class = GutData::ReportDefinition
           when 'dataSet'
             md_class = GutData::Dataset
+          when 'analyticalDashboard'
+            md_class = GutData::AnalyticalDashboard
+          when 'visualizationObject'
+            md_class = GutData::VisualizationObject
           else
             md_class = self
           end


### PR DESCRIPTION
- The two new md classes, `AnalyticalDashboard` and `VisualizationObject` were both backported from the mainline `gooddata-ruby` gem, but neither in the mainline nor out fork did we add these into the indexer.