### PR TITLE
Bump `rexml` from 3.2.5 to 3.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rexml (3.2.5)
+    rexml (3.4.1)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
       rspec-expectations (~> 3.11.0)


### PR DESCRIPTION
No breaking changes listed in the [changelog](https://github.com/ruby/rexml/releases) because we are on Ruby 2.7. 